### PR TITLE
Update to Swift 3.1

### DIFF
--- a/Birthdays/BirthdaysList/BirthdaysListDataProvider.swift
+++ b/Birthdays/BirthdaysList/BirthdaysListDataProvider.swift
@@ -10,61 +10,61 @@ import UIKit
 
 class BirthdaysListDataProvider: NSObject, UITableViewDataSource {
 
-  private let cellIdentifer = "Cell"
-  private var birthdays = [Birthday]()
-  private let gregorian = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)
-  var todayComponents: NSDateComponents?
-  var today: NSDate? {
-    didSet {
-      if let today = today {
-        todayComponents = gregorian?.components([.Month, .Day, .Year], fromDate: today)
-      }
+    private let cellIdentifer = "Cell"
+    var birthdays = [Birthday]()
+    private let gregorian = NSCalendar(calendarIdentifier: NSCalendar.Identifier.gregorian)
+    var todayComponents: NSDateComponents?
+    var today: NSDate? {
+        didSet {
+            if let today = today {
+                todayComponents = gregorian?.components([.month, .day, .year], from: today as Date) as NSDateComponents?
+            }
+        }
     }
-  }
-  
-  func registerCellsForTableView(tableView: UITableView) {
-    tableView.registerClass(BirthdayCell.self, forCellReuseIdentifier: cellIdentifer)
-  }
-  
-  func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return birthdays.count
-  }
-  
-  func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifer, forIndexPath: indexPath) as! BirthdayCell
-    
-    let birthday = birthdays[indexPath.row]
-    cell.updateWithItem(birthday, progress: progressUntilBirthday(birthday))
-    
-    return cell
-  }
-  
-  func progressUntilBirthday(birthday: Birthday) -> Float {
-    
-    guard let todayComponents = todayComponents else { return 0.0 }
 
-    let calculationComponents = birthday.birthday.copy() as! NSDateComponents
-    calculationComponents.year = todayComponents.year
-    
-    if calculationComponents.month < todayComponents.month ||
-      (calculationComponents.month == todayComponents.month &&
-        calculationComponents.day < todayComponents.day) {
-      
-      calculationComponents.year += 1 // Swift 3 compliant ...
+    func registerCellsForTableView(tableView: UITableView) {
+        tableView.register(BirthdayCell.self, forCellReuseIdentifier: cellIdentifer)
     }
-    
-    let components = gregorian?.components([.Day],
-                                           fromDateComponents: todayComponents,
-                                           toDateComponents: calculationComponents,
-                                           options: [])
-    
-    return 1.0-Float(components!.day)/Float(365)
-  }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return birthdays.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifer, for: indexPath as IndexPath) as! BirthdayCell
+
+        let birthday = birthdays[indexPath.row]
+        cell.updateWithItem(item: birthday, progress: progressUntilBirthday(birthday: birthday))
+
+        return cell
+    }
+
+    func progressUntilBirthday(birthday: Birthday) -> Float {
+
+        guard let todayComponents = todayComponents else { return 0.0 }
+
+        let calculationComponents = birthday.birthday.copy() as! NSDateComponents
+        calculationComponents.year = todayComponents.year
+
+        if calculationComponents.month < todayComponents.month ||
+            (calculationComponents.month == todayComponents.month &&
+                calculationComponents.day < todayComponents.day) {
+
+            calculationComponents.year += 1 // Swift 3 compliant ...
+        }
+
+        let components = gregorian?.components([.day],
+                                               from: todayComponents as DateComponents,
+                                               to: calculationComponents as DateComponents,
+                                               options: [])
+
+        return 1.0-Float(components!.day!)/Float(365)
+    }
 }
 
 extension BirthdaysListDataProvider {
-  func addBirthday(birthday: Birthday) {
-    birthdays.append(birthday)
-    birthdays.sortInPlace { progressUntilBirthday($0) > progressUntilBirthday($1) }
-  }
+    func addBirthday(birthday: Birthday) {
+        birthdays.append(birthday)
+        birthdays.sort { progressUntilBirthday(birthday: $0) > progressUntilBirthday(birthday: $1) }
+    }
 }

--- a/Birthdays/BirthdaysList/BirthdaysListViewController.swift
+++ b/Birthdays/BirthdaysList/BirthdaysListViewController.swift
@@ -10,39 +10,61 @@ import UIKit
 import ContactsUI
 
 class BirthdaysListViewController: UITableViewController {
-  
-  var dataProvider: BirthdaysListDataProvider?
-  
-  override func viewDidLoad() {
-    
-    tableView.dataSource = dataProvider
-    
-    dataProvider?.registerCellsForTableView(tableView)
-    
-    let addButton = UIBarButtonItem(barButtonSystemItem: .Add, target: self, action: "addPerson")
-    navigationItem.rightBarButtonItem = addButton
-  }
-  
-  override func viewWillAppear(animated: Bool) {
-    super.viewWillAppear(animated)
-    dataProvider?.today = NSDate()
-  }
-  
-  func addPerson() {
-    let picker = CNContactPickerViewController()
-    picker.delegate = self
-    presentViewController(picker, animated: true, completion: nil)
-  }
+
+    // MARK: Properties
+    var dataProvider: BirthdaysListDataProvider?
+
+    // MARK: LifeCycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem()
+        view.backgroundColor = UIColor.red
+
+        // Tell self to get data from the data provider
+        tableView.dataSource = dataProvider
+        dataProvider?.registerCellsForTableView(tableView: tableView)
+
+        let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(BirthdaysListViewController.addPerson))
+        navigationItem.rightBarButtonItem = addButton
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        dataProvider?.today = NSDate()
+    }
+
+    func addPerson() {
+        let picker = CNContactPickerViewController()
+        picker.delegate = self
+        picker.predicateForEnablingContact = NSPredicate(format: "birthday.@count > 0")
+        present(picker, animated: true, completion: nil)
+    }
 }
 
 extension BirthdaysListViewController: CNContactPickerDelegate {
-  func contactPicker(picker: CNContactPickerViewController, didSelectContact contact: CNContact) {
-  
-    if let birthday = contact.birthday {
-      let person = Birthday(firstName: contact.givenName, lastName: contact.familyName, birthday: birthday)
-      print(person)
-      dataProvider?.addBirthday(person)
-      tableView.reloadData()
+    func contactPicker(_ picker: CNContactPickerViewController, didSelect contact: CNContact){
+
+//        don't need if let because used predicate to only enable with birthday!
+//        if let birthday = contact.birthday {
+            let person = Birthday(firstName: contact.givenName, lastName: contact.familyName, birthday: contact.birthday! as NSDateComponents)
+            print(person)
+            dataProvider?.addBirthday(birthday: person)
+            tableView.reloadData()
+//        }
     }
-  }
+    func contactPickerDidCancel(_ picker: CNContactPickerViewController) {
+        print("Cancel Contact Picker")
+    }
 }
+
+
+
+
+
+


### PR DESCRIPTION
I created this project (starting with the blog post) in Xcode 8.3.3 (Swift 3.1). These changes update the BirthdayListViewController and the BirthdayListDataProvider so that it works in Swift 3.1. 

I only added one item of functionality - an enabling predicate for the contact picker:
`picker.predicateForEnablingContact = NSPredicate(format: "birthday.@count > 0")`